### PR TITLE
Fetches cask repository before attempting to install brew-cask

### DIFF
--- a/mac.sh
+++ b/mac.sh
@@ -62,6 +62,7 @@ println "Updating Homebrew formulas..."
 brew update
 
 println "Installing Brew Cask..."
+  brew tap caskroom/cask
   brew_install_or_upgrade 'caskroom/cask/brew-cask'
 
 println "Installing Firefox..."


### PR DESCRIPTION
Hey @etagwerker 

We were running the script on @cecilia-ombulabs's MacBook Air and this line: `brew_install_or_upgrade 'caskroom/cask/brew-cask'` fails, asking to tap the repo as the formula is not available. 

It should work correctly now.

Please check it out! 
