### PR TITLE
Escaped <application> placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ sudo chown -R $(whoami):admin /opt/homebrew-cask/
 sudo chown -R $(whoami):admin /usr/local/
 ```
 
-## But I don't want <application> installed. 
+## But I don't want \<application> installed. 
 
-Just remove <application> from https://github.com/ombulabs/setup/blob/master/mac.sh
+Just remove \<application> from https://github.com/ombulabs/setup/blob/master/mac.sh
 
 ## Contributions
 


### PR DESCRIPTION
Hey @etagwerker, @schmierkov, 

This PR fixes the README so that `<application>` actually shows up, it's displaying `But I don't want installed` instead of `But I don't want <application> installed`. See: https://github.com/gollum/gollum/issues/713#issuecomment-119923634

Please check it out, thanks! 